### PR TITLE
v1.0.37: fixed timing issue in output stream redirect of Execute

### DIFF
--- a/FitNesseConfigure/FitNesseConfigureV1/task.json
+++ b/FitNesseConfigure/FitNesseConfigureV1/task.json
@@ -1,10 +1,10 @@
-{
+﻿{
     "id":  "51813574-d846-4f39-8cd3-ea20a1296ca4",
     "name":  "FitNesseConfigure",
     "friendlyName":  "Configure FitNesse",
     "description":  "Configure FitNesse for FitSharp so it can be used to execute tests",
     "author":  "Rik Essenius",
-    "helpMarkDown":  "Version 1.0.32",
+    "helpMarkDown":  "Version 1.0.37",
     "category":  "Azure Pipelines",
     "demands":  [
 
@@ -12,7 +12,7 @@
     "version":  {
                     "Major":  1,
                     "Minor":  0,
-                    "Patch":  32
+                    "Patch":  37
                 },
     "minimumAgentVersion":  "1.95.0",
     "instanceNameFormat":  "FitNesseDeploy",

--- a/FitNesseRun/FitNesseRunV1/task.json
+++ b/FitNesseRun/FitNesseRunV1/task.json
@@ -4,7 +4,7 @@
     "friendlyName":  "Run FitNesse Test",
     "description":  "Run a FitNesse test via local deployment or calling an external instance",
     "author":  "Rik Essenius",
-    "helpMarkDown":  "Version 1.0.32",
+    "helpMarkDown":  "Version 1.0.37",
     "category":  "Azure Pipelines",
     "demands":  [
 
@@ -12,7 +12,7 @@
     "version":  {
                     "Major":  1,
                     "Minor":  0,
-                    "Patch":  32
+                    "Patch":  37
                 },
     "minimumAgentVersion":  "1.95.0",
     "instanceNameFormat":  "FitNesseRun $(TestSpec)",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,8 +1,8 @@
-{
+﻿{
     "manifestVersion":  1,
     "id":  "FitNesseRun",
     "name":  "FitNesseRun",
-    "version":  "1.0.32",
+    "version":  "1.0.37",
     "publisher":  "rikessenius",
     "public":  true,
     "targets":  [


### PR DESCRIPTION
Fixed timing issue in output stream redirect of Execute. To be able to read both Output and Error, one is read synchronously and one asynchronously. The asynchronous read is flaky with large volumes of data (sections might get out of order) so FitNesseRun now reads Output synchronously and Error asynchronously.